### PR TITLE
Allow the initialize npc script to be run multiple times

### DIFF
--- a/Server/db/InitializeNpcs.sh
+++ b/Server/db/InitializeNpcs.sh
@@ -14,6 +14,7 @@ tail -n +2 "Npcs.csv" > "Npcs.init"
 
 # Import to sqlite3
 sqlite3 Oldentide.db <<EOF
+delete from npcs;
 .headers on
 .mode csv
 .import Npcs.init npcs


### PR DESCRIPTION
Unless you find this dangerous? I just feel like when we're going to start editing lots of npcs, we'll be running this constantly.

Also, `make db` in the Server folder doesn't seem to do anything?